### PR TITLE
Make sure AppVeyor Windows builds use Node 10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 version: '{branch}-{build}'
 
 environment:
+  nodejs_version: "10"
   YARN_GPG: no
 
   matrix:
@@ -16,6 +17,7 @@ cache:
 stack: node 10
 
 install:
+  - cmd: PowerShell.exe "Install-Product node $env:nodejs_version"
   - node --version && yarn --version && python --version
   - sh: sudo apt-get --yes install libx11-dev libxkbfile-dev
   - cmd: yarn


### PR DESCRIPTION
I am sending this as a separate PR as I want to make sure that CI passes on AppVeyor and Travis.